### PR TITLE
Fix scraper for 9th term

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -26,11 +26,17 @@ def ocd_lookup
 end
 
 def scrape_list(url,browser)
-  browser.visit(url)
-  browser.click_button 'Show all at once'
-  browser.find_all('//body/table/tbody/tr[position()>2 and position()<last()]').map  do |row|
-    scrape_table_row(url, row)
-  end
+  %w[a e i o u].map do |vowel|
+    browser.visit(url)
+    browser.click_link 'Search Other Parliaments'
+    browser.find("//input[contains(@name, '.sKey')]").set(vowel) # Search box
+    browser.find("//select[contains(@name, '.pal')]").select('Only The 9th Parliament') # Term dropdown
+    browser.find('//input[@value="Search Now"]').click
+    browser.click_button 'Show all at once' if browser.has_button?('Show all at once')
+    browser.find_all('//body/table/tbody/tr[position()>2 and position()<last()]').map  do |row|
+      scrape_table_row(url, row)
+    end
+  end.flatten.uniq { |person| person[:id] }
 end
 
 def scrape_table_row(url, row)

--- a/scraper.rb
+++ b/scraper.rb
@@ -12,8 +12,8 @@ def scrape(url)
   people = scrape_list(url,browser)
   # we completely walk the list DOM then go to the individual mp pages so we can use the same Capybara session
   people.each do  |basic_details|
-    more_details =  scrape_person(basic_details['source'], browser)
-    ScraperWiki.save_sqlite(['id'], basic_details.merge(more_details))
+    more_details =  scrape_person(basic_details[:source], browser)
+    ScraperWiki.save_sqlite([:id], basic_details.merge(more_details))
   end
 
 end
@@ -43,8 +43,8 @@ def scrape_table_row(url, row)
   person[:family_name] = names.last
   person[:sort_name] = "#{names.last}, #{names.first}"
 
-  person['id'] = year + '-'+/&j=(?<id>\d*)&const/.match(absolute_uri)[:id].to_s
-  person['source'] = absolute_uri
+  person[:id] = year + '-'+/&j=(?<id>\d*)&const/.match(absolute_uri)[:id].to_s
+  person[:source] = absolute_uri
   person[:url] = absolute_uri
   person[:district] = row.find('./td[position()=4]').text.strip
   person[:constituency] = row.find('./td[position()=3]').text.strip


### PR DESCRIPTION
This fixes the current scraper to work with term 9 again. This has been broken since term 10 started, when they removed the list of MPs and replaced it with this message:

![screen shot 2016-08-22 at 17 57 25](https://cloud.githubusercontent.com/assets/22996/17863558/f8984bb4-6891-11e6-8c2b-8cdd02125f9f.png)

To work around this we now do a search for each vowel in turn to get a hopefully complete list of people.

Part of https://github.com/everypolitician/everypolitician-data/issues/15883